### PR TITLE
Store a list of all linked files under `installed.txt`

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -306,6 +306,7 @@ function _fisher_pkg_install -a pkg
                 end
         end
         echo "linking $target" | command sed "s|$HOME|~|" >&2
+        echo $target >> $fisher_config/installed.txt
         command ln -f $source $target
         switch $target
             case \*.fish


### PR DESCRIPTION
Create a list of installed files that are linked from package installation under `$fisher_config/installed.txt`.