### PR TITLE
Optimize fisher startup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Your shell can take a few seconds before refreshing the function path. If `fishe
 
 ### Dependencies
 
-- [fish](https://github.com/fish-shell/fish-shell) 2.0+ (prefer 2.3 or newer)
+- [fish](https://github.com/fish-shell/fish-shell) 2.1+ (prefer 2.3 or newer)
 - [curl](https://github.com/curl/curl) 7.10.3+
 - [git](https://github.com/git/git) 1.7.12+
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,13 @@ end
 
 ### Changing the installation prefix
 
-Use the `$fisher_path` environment variable to change the prefix location where functions, completions, and configuration snippets will be copied to when a package is installed. The default location will be your fish configuration directory or `~/.config/fish` if you followed the instructions above.
-
-Make sure to append your functions and completions directories to the `$fish_function_path` and `$fish_complete_path` environment variables so that they can be autoloaded by fish in future sessions and to run [configuration snippets](#configuration-snippets) on shell startup. Here is a boilerplate configuration you can use in your own fish configuration.
+Use the `$fisher_path` environment variable to change the location where functions, completions, and [configuration snippets](#configuration-snippets) will be copied to when a package is installed. The default location will be your fish configuration directory.
 
 ```fish
 set -g fisher_path /path/to/another/location
 
-set fish_function_path $fish_function_path $fisher_path/functions
-set fish_complete_path $fish_complete_path $fisher_path/completions
+set fish_function_path $fish_function_path[1] $fisher_path/functions $fish_function_path
+set fish_complete_path $fish_complete_path[1] $fisher_path/completions $fish_complete_path
 
 for file in $fisher_path/conf.d/*.fish
     builtin source $file 2> /dev/null

--- a/fisher.fish
+++ b/fisher.fish
@@ -23,13 +23,13 @@ function fisher -a cmd -d "fish package manager"
 
     if test ! -e "$fisher_path/conf.d/fisher.fish"
         switch "$version"
-            case 2\*
+            case 2\* \*-\*
                 echo "fisher copy-user-key-bindings" > $fisher_path/conf.d/fisher.fish
         end
 
     else
         switch "$version"
-            case 2\*
+            case 2\* \*-\*
             case \*
                 command rm -f $fisher_path/conf.d/fisher.fish
         end

--- a/fisher.fish
+++ b/fisher.fish
@@ -1,16 +1,5 @@
 set -g fisher_version 3.1.1
 
-switch (command uname)
-    case Darwin FreeBSD
-        function _fisher_now -a elapsed
-            command perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - $ARGV[0])' $elapsed
-        end
-    case \*
-        function _fisher_now -a elapsed
-            command date "+%s%3N" | command awk -v ELAPSED="$elapsed" '{ sub(/%?3N$/, "000") } $0 -= ELAPSED'
-        end
-end
-
 function fisher -a cmd -d "fish package manager"
     set -q XDG_CACHE_HOME; or set XDG_CACHE_HOME ~/.cache
     set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME ~/.config
@@ -449,5 +438,14 @@ function _fisher_wait
     while for job in $argv
             contains -- $job (_fisher_jobs); and break
         end
+    end
+end
+
+function _fisher_now -a elapsed
+    switch (command uname)
+        case Darwin FreeBSD
+            command perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - $ARGV[0])' $elapsed
+        case \*
+            command date "+%s%3N" | command awk -v ELAPSED="$elapsed" '{ sub(/%?3N$/, "000") } $0 -= ELAPSED'
     end
 end

--- a/fisher.fish
+++ b/fisher.fish
@@ -40,7 +40,8 @@ function fisher -a cmd -d "fish package manager"
 
     else
         switch "$version"
-            case \*-\* 3\*
+            case 2\*
+            case \*
                 command rm -f $fisher_path/conf.d/fisher.fish
         end
     end
@@ -140,11 +141,6 @@ function _fisher_self_update -a file
     set -l url "https://raw.githubusercontent.com/jorgebucaran/fisher/master/fisher.fish"
     echo "fetching $url" >&2
 
-    if not type -p curl >/dev/null 2>&1
-        echo "curl is required to update fisher -- install curl and try again" >&2
-        return 1
-    end
-
     command curl -s "$url?nocache" >$file@
 
     set -l next_version (awk 'NR == 1 { print $4; exit }' < $file@)
@@ -229,11 +225,6 @@ function _fisher_pkg_fetch_all
     set -l local_pkgs
     set -l actual_pkgs
     set -l expected_pkgs
-
-    if not type -p curl >/dev/null 2>&1
-        echo "curl is required to use fisher -- install curl and try again" >&2
-        return 1
-    end
 
     for id in $argv
         switch $id


### PR DESCRIPTION
With the addition of keybinding support for fish 2.x, fisher greatly
increases shell startup time (50-100ms in my testing). This is due to a
number of reasons, including using less-than-ideal builtins,
unconditionally running mkdir, unconditionally recreating
conf.d/fisher.fish, and checking for curl on startup (instead of when
curl is used).

This patch cuts fisher-related startup time to roughly 25ms, simplifying
the code paths as much as I am able.

The source function is removed as a compromise for speed. Fish 2.1 and
greater support `source`, and supporting fish 2.0 is not worth a hefty
speed penalty in my opinion.

curl checks have been moved to the two uses of curl -- there is some
duplication now so this may be slightly less ideal. Also, curl checks
are now done with the builtin `type` instead of `which`, which is not
guaranteed to exist.