### PR TITLE
docs: fix configuration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Use the `$fisher_path` environment variable to change the location where functio
 ```fish
 set -g fisher_path /path/to/another/location
 
-set fish_function_path $fish_function_path[1] $fisher_path/functions $fish_function_path
-set fish_complete_path $fish_complete_path[1] $fisher_path/completions $fish_complete_path
+set fish_function_path $fish_function_path[1] $fisher_path/functions $fish_function_path[2..-1]
+set fish_complete_path $fish_complete_path[1] $fisher_path/completions $fish_complete_path[2..-1]
 
 for file in $fisher_path/conf.d/*.fish
     builtin source $file 2> /dev/null


### PR DESCRIPTION
Avoid doubling paths in `fish_function_path` and `fish_complete_path`.