### PR TITLE
Override fishfile content instead of replacing the file

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -240,8 +240,7 @@ function _fisher_commit -a cmd
         end
     end
 
-    _fisher_fmt <$fishfile | _fisher_write $cmd $actual_pkgs >$fishfile.
-    command mv -f $fishfile. $fishfile
+    printf "%s\n" (_fisher_fmt <$fishfile | _fisher_write $cmd $actual_pkgs) >$fishfile
 
     _fisher_self_complete
 


### PR DESCRIPTION
This allows fishfile to be a symlink, which I used to keep track of my
dotfiles in a repo, and broke after upgrading to V3.