### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository -y ppa:fish-shell/nightly-master
+          sudo apt-get update
+          sudo apt-get -y install fish
+      - name: Fetch and validate fisher install
+        run: |
+          curl https://git.io/fisher --create-dirs -sLo ~/.config/fish/functions/fisher.fish
+          fish -c "fisher -v && fisher -h"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: required
-before_install:
-    - sudo add-apt-repository -y ppa:fish-shell/nightly-master
-    - sudo apt-get update
-    - sudo apt-get -y install fish
-script:
-    - curl https://git.io/fisher --create-dirs -sLo ~/.config/fish/functions/fisher.fish
-    - fish -c "fisher -v && fisher -h"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fisher [![Releases](https://img.shields.io/github/release/jorgebucaran/fisher.svg?label=&color=0366d6)](https://github.com/jorgebucaran/fisher/releases/latest)
+# Fisher [![Releases](https://img.shields.io/github/release/jorgebucaran/fisher.svg?label=&color=0366d6)](https://github.com/jorgebucaran/fisher/releases/latest) ![Continuous Integration](https://github.com/jorgebucaran/fisher/workflows/Continuous%20Integration/badge.svg)
 
 Fisher is a package manager for the <a href="https://fishshell.com" title="friendly interactive shell">fish shell</a>. It defines a common interface for package authors to build and distribute shell scripts in a portable way. You can use it to extend your shell capabilities, change the look of your prompt and create repeatable configurations across different systems effortlessly.
 
@@ -237,7 +237,7 @@ You can install it with the `add` command followed by the path to the directory.
 fisher add /absolute/path/to/fish-readme
 ```
 
-To publish your pacckage put your code on GitHub, GitLab, BitBucket, or anywhere you like. Fisher is not a package registry. Its function is to fetch fish scripts and put them in place so that your shell can find them. 
+To publish your pacckage put your code on GitHub, GitLab, BitBucket, or anywhere you like. Fisher is not a package registry. Its function is to fetch fish scripts and put them in place so that your shell can find them.
 
 Now let's install the package from the net. Open your [fishfile](#using-the-fishfile) and replace the local version of the package you added with the URL of the repository. Save your changes and run `fisher`.
 


### PR DESCRIPTION
Migration will switch from Travis CI to GitHub Actions. This PR covers the following:

* Removal of Travis CI configuration
* Addition of Continuous Integration GitHub Action
* Addition of GitHub Action badge in README

This will close #567.