### PR TITLE
self-update: better network error handling

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -155,26 +155,16 @@ end
 function _fisher_self_update -a file
     set -l url "https://raw.githubusercontent.com/jorgebucaran/fisher/master/fisher.fish"
     echo "fetching $url" >&2
+    command curl -s "$url?nocache" >$file.
 
-    set -l http_code (command curl -sw '%{http_code}' "$url?nocache" -o $file.)
-    set -l curl_code $status
-
-    if test $http_code -ne 200
-        echo -n "fisher: cannot update fisher -- " >&2
-
-        if test $curl_code -eq 0
-            echo "got http code $http_code, expected 200" >&2
-        else
-            echo "curl exited with code $curl_code, expected 0" >&2
-        end
-        command rm -f $file.
-        return 1
-    end
-
-    set -l next_version (command awk '{ print $4 } { exit }' <$file.)
+    set -l next_version (command awk '$4 ~ /^[0-9]+\.[0-9]+\.[0-9]+$/ { print v=$4 } { exit !v }' <$file.)
     switch "$next_version"
-        case $fisher_version
+        case "" $fisher_version
             command rm -f $file.
+            if test -z "$next_version"
+                echo "fisher: cannot update fisher -- are you offline?" >&2
+                return 1
+            end
             echo "fisher is already up-to-date" >&2
         case \*
             echo "linking $file" | command sed "s|$HOME|~|" >&2

--- a/fisher.fish
+++ b/fisher.fish
@@ -155,14 +155,20 @@ end
 function _fisher_self_update -a file
     set -l url "https://raw.githubusercontent.com/jorgebucaran/fisher/master/fisher.fish"
     echo "fetching $url" >&2
-    command curl -s "$url?nocache" >$file.
+    set -l curl_response (command curl -fsS "$url?nocache" -o $file. 2>&1)
+
+    if test $status -ne 0
+        echo "fisher: cannot update fisher -- $curl_response" >&2
+        command rm -f $file.
+        return 1
+    end
 
     set -l next_version (command awk '{ print $4 } { exit }' <$file.)
     switch "$next_version"
         case "" $fisher_version
             command rm -f $file.
             if test -z "$next_version"
-                echo "fisher: cannot update fisher -- are you offline?" >&2
+                echo "fisher: cannot update fisher -- unable to determine remote version" >&2
                 return 1
             end
             echo "fisher is already up-to-date" >&2

--- a/fisher.fish
+++ b/fisher.fish
@@ -155,9 +155,8 @@ end
 function _fisher_self_update -a file
     set -l url "https://raw.githubusercontent.com/jorgebucaran/fisher/master/fisher.fish"
     echo "fetching $url" >&2
-    set -l curl_response (command curl -fsS "$url?nocache" -o $file. 2>&1)
 
-    if test $status -ne 0
+    if not set -l curl_response (command curl -fsS "$url?nocache" -o $file. 2>&1)
         echo "fisher: cannot update fisher -- $curl_response" >&2
         command rm -f $file.
         return 1


### PR DESCRIPTION
By using curl's `-f` option, we improve the self-update mechanism by not overwriting the fisher script if the HTTP status code given to us by Github is higher than 400.

Additionally, we make sure that the exit code of the curl process must be always zero for the self-update to succeed.

The `-S` option, when used with `-s`, allows us to get an error message from curl when it fails.

A few examples:

![image](https://user-images.githubusercontent.com/626206/88517680-a01d4080-cfc5-11ea-88f9-8be5cbb0f474.png)

Fixes #578 