### PR TITLE
fix uninstall plugin event instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ fish-fishfile-quick-edit
 ```fish
 bind \cg "vi ~/.config/fish/fishfile"
 
-set -l name (basename (status -f) .fish){_uninstall}
+set -l name (basename (status -f) .fish)_uninstall
 
 function $name --on-event $name
     bind --erase \cg


### PR DESCRIPTION
Based on my tests, in a file named `fzf.fish`

```
echo (basename (status -f) .fish){_uninstall}
fzf{_uninstall}
```
but
```
echo (basename (status -f) .fish)_uninstall
fzf_uninstall
```

So I think there's a bug in the instructions.