### PR TITLE
Use HTTPS for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Looking for plugins? Browse [git.io/awsm.fish](https://git.io/awesome.fish) or [
 ## Installation
 
 ```console
-curl -sL git.io/fisher | source && fisher install jorgebucaran/fisher
+curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
 ```
 
 ## Quickstart


### PR DESCRIPTION
Using HTTPS would help prevent: 

* accidentally running a captive portal login screen as a fish script and sourcing it
* and other obvious security and privacy benefits of HTTPS