### PR TITLE
Implements comments for fish_plugins

### DIFF
--- a/.github/workflows/fork-sync.yaml
+++ b/.github/workflows/fork-sync.yaml
@@ -1,0 +1,20 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          owner: jorgebucaran
+          base: main
+          head: main
+          merge_method: rebase

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -97,7 +97,8 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                     set files $source/* && string match --quiet --regex -- .+\.fish\\\$ \$files || exit
 
-                    echo \"fisher: Plugin not supported: \\\"$plugin\\\"\" >&2
+                    cp -f (string match --regex -- .+\.fish\\\$ \$files) $source/functions/
+                    echo \"fisher: Plugin depricated (but still works): \\\"$plugin\\\"\" >&2
                     echo (set_color --bold red)\"Support for .fish files outside a functions directory is deprecated\" (set_color --underline)https://github.com/jorgebucaran/fisher/issues/651(set_color normal) >&2
                 " &
 


### PR DESCRIPTION
This PR aims to implement a simple comment system to address #635.

Commit 11eb085 had linked #524 of deprecating `fishfile` for `fish_plugins`, which is nice but comments supports are dropped, perheps due to the previous `filefile`'s complexity.

This PR aims to introduce a simple and easy to maintain comment system back to `fish_plugins` (partly based on ae770fc). Currently, this commit works on both full line comments and inline comments (where there should be at least one whitespace before the first # character), using only built-in fish-shell string regex.

## Explaination:
The following
```fish
string match --regex -- '^[^#\s]+' <$fish_plugins
```
can essentially strip away any full or inline comments as it captures from the beginning of the line to the first non-whitespace non-# character.

Then, in the logic of writing back to `$fish_plugins`, we first use
```fish
# match line comments, active plugins (+ optional inline comments) in fish_plugins
set --local -- new_content (string match --regex -- '^\s*#.*$|^(?:'(
    string join -- '|' $_fisher_plugins)')(?:\s+#.*)?$' <$fish_plugins)
```
to construct a regex with the installed active plugins to filter out the content of `$fish_plugins`. The regex only match fullline comments (`'^\s*#.*$`), active plugins, and an optional inline-comment capture group (`(?:\s+#.*)?`) after the active plugins. Note that we had checked `$_fisher_plugins[1]` to be defined so the string join should always has at least one item.

Finally, 
```fish
# inverse match active plugins against the (comment stripped) $new_content
set --append -- new_content (string match --regex --invert -- '^(?:'(
    string join -- '|' (string match --regex -- '^[^#\s]+' $new_content))')$' $_fisher_plugins)
```
first strips away any full/inline comments from `$new_content`, then performs an exact inverse match so that any newly installed plugins in `$_fisher_plugins` that are currently not present in `$fish_plugins` would be added to `$new_content`. As an added bonus, the contents and comments in `$fish_plugins` will be order-preserved with this approach, and newly installed plugins are appended at the end of the file.
