### PR TITLE
Add basic manual page support

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -186,11 +186,11 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
                 end
 
                 for man in (string match --regex -- '.+/manpages/([^/]+)\.(\d)$' $$plugin_files_var)
-		            if set --local name (string match --regex -- '.+/([^/]+)\.(\d)' $man)
+                    if set --local name (string match --regex -- '.+/([^/]+)\.(\d)' $man)
                         if test (ln -s $fisher_path/manpages/$name[2].$name[3] /usr/share/man/man$name[3]/$name[2].$name[3]) $status -ne 0
                             echo "fisher: Cannot symlink manual page $fisher_path/manpages/$name[2].$name[3] at /usr/share/man/man$name[3]/$name[2].$name[3]" >&2
                         end
-		            end
+                    end
                 end
             end
 


### PR DESCRIPTION
@jorgebucaran I've been toying with the ability to install man pages with `fisher` plugins and would like your input if possible. The changes I've proposed here add basic functionality for man pages, and can be seen to work when using the [pond](https://github.com/marcransome/pond) plugin:

```console
$ fisher install marcransome/pond@feature/stdin
fisher install version 4.2.0
Fetching https://codeload.github.com/marcransome/pond/tar.gz/feature/stdin
Installing marcransome/pond@feature/stdin
           /home/nobody/.config/fish/functions/pond.fish
           /home/nobody/.config/fish/conf.d/pond.fish
           /home/nobody/.config/fish/completions/pond.fish
           /home/nobody/.config/fish/manpages/pond.1
Installed 1 plugin/s
```

The man page should be available as expected:
```
$ man pond
...
```

<hr>

Files matching the pattern `manpages/<name>.<section-number>` are installed to `$fisher_path/manpages` and symbolic links are created at `/usr/share/man/man<section-number>/<name>.<section-number>`. Manual files and symbolic links are removed when a plugin is uninstalled.


I'd like to get some feedback regarding the changes, as well as any thoughts you might have on how to handle different locales (e.g. `<my-project>/manpages/<locale>/<name>.<section-number>`. 🤔 