### PR TITLE
fisher.fish: Use short-option style for tar

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -86,7 +86,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if curl --silent \$url | tar --extract --gzip --directory \$temp --file - 2>/dev/null
+                        if curl --silent \$url | tar -xz -C \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -86,7 +86,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if curl --silent \$url | tar -xz -C \$temp -f - 2>/dev/null
+                        if curl --silent \$url | tar -xzC \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2


### PR DESCRIPTION
OpenBSD's tar command unfortunately doesn't support long options (see https://man.openbsd.org/tar). Using short options ensures compatibility with OpenBSD systems.

Also see https://github.com/jorgebucaran/fisher/issues/489