### PR TITLE
Docs: add bootstrap note 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,19 @@ Manage functions, completions, bindings, and snippets from the command line. Ext
 ## Installation
 
 ```console
-curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
+curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher   
+```
+
+## Bootstrap
+
+If you want to automate installing fisher in a new system when it isn't already installed, add the following at the top of your ~/.config/fish/config.fish.
+
+This will install fisher and download all the plugins listed in your *fish_plugins* file.
+
+```fish
+if status is-interactive && ! functions --query fisher
+    curl -sL https://git.io/fisher | source && fisher update
+end 
 ```
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you want to automate installing fisher in a new system when it isn't already 
 
 This will install fisher and download all the plugins listed in your *fish_plugins* file.
 
-```fish
+```console
 if status is-interactive && ! functions --query fisher
     curl -sL https://git.io/fisher | source && fisher update
 end 


### PR DESCRIPTION
This note is important because there are certain caveats when bootstrapping fisher:
1. User without this instruction might run into a loop. #644
2. User who follows the standard installation process and trying to couple that into a bootstrap script will run into this issue #670 where the whole fish_plugins is overwritten

I borrowed the wording from this commit  dadcc6c