### PR TITLE
Improve fisher autocompletions

### DIFF
--- a/completions/fisher.fish
+++ b/completions/fisher.fish
@@ -1,7 +1,8 @@
+set --local fisher_subcommands install update remove list
 complete --command fisher --exclusive --long help --description "Print help"
 complete --command fisher --exclusive --long version --description "Print version"
-complete --command fisher --exclusive --condition __fish_use_subcommand --arguments install --description "Install plugins"
-complete --command fisher --exclusive --condition __fish_use_subcommand --arguments update --description "Update installed plugins"
-complete --command fisher --exclusive --condition __fish_use_subcommand --arguments remove --description "Remove installed plugins"
-complete --command fisher --exclusive --condition __fish_use_subcommand --arguments list --description "List installed plugins matching regex"
+complete --command fisher --exclusive --condition "not __fish_seen_subcommand_from $fisher_subcommands" --arguments install --description "Install plugins"
+complete --command fisher --exclusive --condition "not __fish_seen_subcommand_from $fisher_subcommands" --arguments update --description "Update installed plugins"
+complete --command fisher --exclusive --condition "not __fish_seen_subcommand_from $fisher_subcommands" --arguments remove --description "Remove installed plugins"
+complete --command fisher --exclusive --condition "not __fish_seen_subcommand_from $fisher_subcommands" --arguments list --description "List installed plugins matching regex"
 complete --command fisher --exclusive --condition "__fish_seen_subcommand_from update remove" --arguments "(fisher list)"


### PR DESCRIPTION
Fix autocompletions when called like `fisher_path=/some/path fisher [TAB]`.

Closes #703