### PR TITLE
Use current fish path instead of fish command

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -72,13 +72,13 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
             set --local fetch_plugins $update_plugins $install_plugins
             echo (set_color --bold)fisher $cmd version $fisher_version(set_color normal)
 
-            for plugin in $fetch_plugins
+            fish_path=(status fish-path) for plugin in $fetch_plugins
                 set --local source (command mktemp -d)
                 set --append source_plugins $source
 
                 command mkdir -p $source/{completions,conf.d,functions}
 
-                fish --command "
+                $fish_path --command "
                     if test -e $plugin
                         command cp -Rf $plugin/* $source
                     else


### PR DESCRIPTION
`fish` may not be an available command, for example if it was installed through `brew`. Whenever I `rm -r ~/.config/fish/` on my mac (for developing Tide), I have to `fish_add_path /opt/homebrew/bin/` before I run my `fisher` command. Instead, lets just guarantee a valid command by using the path to the current instance of fish. Tide already does this and it has worked fine so far.