### PR TITLE
Fix a compatibility issue with fish 3.0.x

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -28,6 +28,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
             set --local arg_plugins $argv[2..-1]
             set --local old_plugins $_fisher_plugins
             set --local new_plugins
+            set --local fish_path (status fish-path)
 
             test -e $fish_plugins && set --local file_plugins (string match --regex -- '^[^\s]+$' <$fish_plugins)
 
@@ -74,7 +75,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
             set --local fetch_plugins $update_plugins $install_plugins
             echo (set_color --bold)fisher $cmd version $fisher_version(set_color normal)
 
-            fish_path=(status fish-path) for plugin in $fetch_plugins
+            for plugin in $fetch_plugins
                 set --local source (command mktemp -d)
                 set --append source_plugins $source
 


### PR DESCRIPTION
I have a docker image that can install fish, but it is verison 3.0.2. The bash-compatible mechnism of `fish_path=(status fish-path) command` was not added until after 3.0.2, probably 3.1. By setting `fish_path` *earlier* in the fuction, Fisher has full compatibility with this earlier version of Fish 3.