### PR TITLE
Dereference links on install

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -173,7 +173,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
                 end
 
                 for file in (string replace -- $source/ "" $files)
-                    command cp -Rf $source/$file $fisher_path/$file
+                    command cp -RLf $source/$file $fisher_path/$file
                 end
 
                 set --local plugin_files_var _fisher_(string escape --style=var -- $plugin)_files


### PR DESCRIPTION
I have a plugin which shares code for zsh and fish. I'd like to symlink this shared code file to the `functions` directory within the git repository, so that it gets installed by fisher. Unfortunately fisher does not dereference links and hence installs a broken link in this case.

This PR adds the `-L` argument to `cp` in order to dereference links on install and update.