### PR TITLE
prepend `command` to curl and tar

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -98,7 +98,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if curl --silent -L \$url | tar -xzC \$temp -f - 2>/dev/null
+                        if command curl --silent -L \$url | command tar -xzC \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2


### PR DESCRIPTION
This is a pretty trivial change. 

The PR adds the `command` prefix in front of the `curl` and `tar` commands to avoid alias interference.