### PR TITLE
fix: ignore .curlrc file when downloading plugin's tarball

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -98,7 +98,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if command curl --disable --silent --location \$url | command tar -xzC \$temp -f - 2>/dev/null
+                        if command curl --disable --silent -L \$url | command tar -xzC \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -98,7 +98,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if command curl --silent -L \$url | command tar -xzC \$temp -f - 2>/dev/null
+                        if command curl --disable --silent --location \$url | command tar -xzC \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -98,7 +98,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if command curl --disable --silent -L \$url | command tar -xzC \$temp -f - 2>/dev/null
+                        if command curl -q --silent -L \$url | command tar -xzC \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2


### PR DESCRIPTION
When `.curlrc` contains `-O` option, curl saves file to disk instead of redirecting it to stdout. thats why tar fails at next step as there is noting to extract