### PR TITLE
fix: remove conflicting files when plugins aren't indexed

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -167,8 +167,8 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
                     end
 
                     if set --query conflict_files[1] && set --erase install_plugins[$index]
-                        echo -s "fisher: Cannot install \"$plugin\": please remove or move conflicting files first:" \n"        "$conflict_files >&2
-                        continue
+                        echo -s "fisher: Conflicting plugin: \"$plugin\": Removing conflicting files:" \n"        "$conflict_files >&2
+                        rm $conflict_file
                     end
                 end
 


### PR DESCRIPTION
This is an annoying issue in fisher: When you move to a new PC, the `fish_variables` file which includes paths what files, and what plugin isn't present and fisher doesn't want to overwrite those unindexed files, my PR removes those conflicting files and then everything works