### PR TITLE
Use '~' for $HOME in fish_plugins file rather than resolving path

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -29,7 +29,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
             set --local old_plugins $_fisher_plugins
             set --local new_plugins
 
-            test -e $fish_plugins && set --local file_plugins (string match --regex -- '^[^\s]+$' <$fish_plugins)
+            test -e $fish_plugins && set --local file_plugins (string match --regex -- '^[^\s]+$' <$fish_plugins | string replace -- \~ ~)
 
             if ! set --query argv[2]
                 if test "$cmd" != update
@@ -206,7 +206,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
                     contains -- (string lower -- $plugin) (string lower -- $commit_plugins) || set --append commit_plugins $plugin
                 end
 
-                printf "%s\n" $commit_plugins >$fish_plugins
+                string replace --regex -- $HOME \~ $commit_plugins >$fish_plugins
             else
                 set --erase _fisher_plugins
                 command rm -f $fish_plugins


### PR DESCRIPTION
The fish_plugins file isn't portable across machines for local plugins because it stores the path to `$HOME`, which could be different on a different machine. This PR fixes this.

Steps to reproduce with Fisher 4.4.4:

```fish
$ fisher install $__fish_config_dir/plugins/foo
fisher install version 4.4.4
Installing /Users/mattmc3/.config/fish/plugins/foo
           /Users/mattmc3/.config/fish/.fisher/functions/foo.fish
Updated 1 plugin/s
$ cat $__fish_config_dir/fish_plugins
jorgebucaran/fisher
/Users/mattmc3/.config/fish/plugins/foo
```

This PR for Fisher 4.4.5, which makes fish_plugins more portable across machines with alternative user names:

```fish
$ fisher install $__fish_config_dir/plugins/foo
fisher install version 4.4.5
Installing /Users/matt/.config/fish/plugins/foo
           /Users/matt/.config/fish/.fisher/functions/foo.fish
Updated 1 plugin/s
$ cat $__fish_config_dir/fish_plugins
jorgebucaran/fisher
~/.config/fish/plugins/foo
```